### PR TITLE
Towards tweaselORG/tracker-wiki#15: Add a script to generate adapter example data from the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 archive-config.json
 research-docs/archive-errors.json
-research-docs/adapterExamples.json
+research-docs/adapter-examples.json
 
 
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 archive-config.json
 research-docs/archive-errors.json
+research-docs/adapterExamples.json
+
 
 tmp/
 *.tmp

--- a/scripts/debug-adapter.ts
+++ b/scripts/debug-adapter.ts
@@ -2,7 +2,7 @@
 import deepmerge from 'deepmerge';
 import { writeFile } from 'fs/promises';
 import { allAdapters } from '../src/common/adapters';
-import { debugAdapter, mergeAdapterResults } from './lib/debug';
+import { loadTestDataFromDb, mergeTestDataResults } from './lib/test-data';
 
 const adapterArgument = process.argv[2];
 if (!adapterArgument) throw new Error('You need to specify the adapter as the first argument.');
@@ -14,11 +14,11 @@ const mergeResult = process.argv.includes('--merge-result');
     const adapter = allAdapters.find((a) => a.tracker.slug === trackerSlug && a.slug === adapterSlug);
     if (!adapter) throw new Error(`Adapter ${adapterSlug} not found.`);
 
-    const { adapterResults, decodingResults } = await debugAdapter(adapter);
+    const { adapterResults, decodingResults } = await loadTestDataFromDb(adapter);
 
     // We print the adapter results to the console and save the deepmerged decoding results to a file.
     if (mergeResult) {
-        console.dir(mergeAdapterResults(adapterResults), { depth: null });
+        console.dir(mergeTestDataResults(adapterResults), { depth: null });
     } else {
         for (const r of adapterResults) {
             console.dir(r, { depth: null });

--- a/scripts/debug-adapter.ts
+++ b/scripts/debug-adapter.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-console */
-import { Buffer } from 'buffer/index.js';
-import { fetch } from 'cross-fetch';
 import deepmerge from 'deepmerge';
 import { writeFile } from 'fs/promises';
-import { adapterForRequest, decodeRequest, processRequest, type Request } from '../src';
 import { allAdapters } from '../src/common/adapters';
+import { debugAdapter, mergeAdapterResults } from './lib/debug';
 
 const adapterArgument = process.argv[2];
 if (!adapterArgument) throw new Error('You need to specify the adapter as the first argument.');
@@ -16,66 +14,18 @@ const mergeResult = process.argv.includes('--merge-result');
     const adapter = allAdapters.find((a) => a.tracker.slug === trackerSlug && a.slug === adapterSlug);
     if (!adapter) throw new Error(`Adapter ${adapterSlug} not found.`);
 
-    // Fetch requests from Datasette.
-    const adapterClauses = adapter.endpointUrls.map((u) =>
-        u instanceof RegExp
-            ? `endpointUrl regexp '${
-                  // JS escapes slashes in regexes, but sqlite-regex doesn't accept that.
-                  u.source.replace(/\\\//g, '/')
-              }'`
-            : `endpointUrl = '${u}'`
-    );
-    const whereClause = `endpointUrl is not null and (${adapterClauses.join(' or ')})`;
-
-    const requests: Request[] = [];
-    let nextUrl = `https://data.tweasel.org/data/requests.json?_shape=objects&_where=${encodeURIComponent(
-        whereClause
-    )}&_json=headers&_json=cookies&_size=max&_nocol=initiator&_nocol=platform&_nocol=runType&_nofacet=1&_nosuggest=1&_nocount=1`;
-    while (nextUrl) {
-        const res = await fetch(nextUrl).then((r) => r.json());
-        requests.push(...res.rows);
-        nextUrl = res.next_url;
-    }
-
-    const requestsForAdapter = requests
-        // The endpoint URLs may be the same for multiple adapters, so we still need to filter the requests.
-        .filter((r) => {
-            const a = adapterForRequest(r);
-            return a && a.slug === adapter.slug && a.tracker.slug === adapter.tracker.slug;
-        })
-        // And if the content is binary, Datasette encodes it as base64
-        // (https://docs.datasette.io/en/stable/binary_data.html).
-        .map((r) => {
-            const content = r.content as string | { $base64: true; encoded: string } | undefined;
-            if (content && typeof content !== 'string' && content['$base64'] === true)
-                r.content = Buffer.from(content.encoded, 'base64').toString('binary');
-            return r;
-        });
-
-    // We want both the decoding and the full adapter result, so we unfortunately need to run the decoding twice (once
-    // manually, once through the adapter). Luckily, the decoding is fast.
-    const decodingResults = requestsForAdapter.map((r) => decodeRequest(r, adapter.decodingSteps));
-    const adapterResults = requestsForAdapter.map((r) =>
-        processRequest(r)?.reduce<Record<string, unknown[]>>(
-            (acc, cur) => ({
-                ...acc,
-                [cur.property]: acc[cur.property]?.concat(cur.value) || [cur.value],
-            }),
-            {}
-        )
-    );
+    const { adapterResults, decodingResults } = await debugAdapter(adapter);
 
     // We print the adapter results to the console and save the deepmerged decoding results to a file.
     if (mergeResult) {
-        const mergedResult = deepmerge.all(adapterResults.filter(Boolean) as Record<string, unknown>[]);
-        for (const key of Object.keys(mergedResult)) mergedResult[key] = [...new Set(mergedResult[key] as unknown[])];
-        console.dir(mergedResult, { depth: null });
+        console.dir(mergeAdapterResults(adapterResults), { depth: null });
     } else {
         for (const r of adapterResults) {
             console.dir(r, { depth: null });
             console.log();
         }
     }
+
     await writeFile(`merged-decoded-requests.tmp.json`, JSON.stringify(deepmerge.all(decodingResults), null, 4));
 })();
 /* eslint-enable no-console */

--- a/scripts/generate-example-data.ts
+++ b/scripts/generate-example-data.ts
@@ -1,14 +1,13 @@
 import { writeFile } from 'fs/promises';
 import { allAdapters } from '../src/common/adapters';
-import { debugAdapter, mergeAdapterResults } from './lib/debug';
+import { loadTestDataFromDb, mergeTestDataResults } from './lib/test-data';
 
 (async () => {
     const result = await Promise.all(
         allAdapters.map(async (adapter) => {
-            // Without any limit, this might run for very long.
-            const { adapterResults } = await debugAdapter(adapter, { accumulateToPath: true, rowLimit: 200 });
-            return { [`${adapter.tracker.slug}/${adapter.slug}`]: mergeAdapterResults(adapterResults) };
+            const { adapterResults } = await loadTestDataFromDb(adapter, { accumulateToPath: true });
+            return { [`${adapter.tracker.slug}/${adapter.slug}`.toLowerCase()]: mergeTestDataResults(adapterResults) };
         })
     ).then((results) => Object.assign({}, ...results));
-    await writeFile('./research-docs/adapterExamples.json', JSON.stringify(result));
+    await writeFile('./research-docs/adapter-examples.json', JSON.stringify(result));
 })();

--- a/scripts/generate-example-data.ts
+++ b/scripts/generate-example-data.ts
@@ -1,0 +1,14 @@
+import { writeFile } from 'fs/promises';
+import { allAdapters } from '../src/common/adapters';
+import { debugAdapter, mergeAdapterResults } from './lib/debug';
+
+(async () => {
+    const result = await Promise.all(
+        allAdapters.map(async (adapter) => {
+            // Without any limit, this might run for very long.
+            const { adapterResults } = await debugAdapter(adapter, { accumulateToPath: true, rowLimit: 200 });
+            return { [`${adapter.tracker.slug}/${adapter.slug}`]: mergeAdapterResults(adapterResults) };
+        })
+    ).then((results) => Object.assign({}, ...results));
+    await writeFile('./research-docs/adapterExamples.json', JSON.stringify(result));
+})();

--- a/scripts/lib/debug.ts
+++ b/scripts/lib/debug.ts
@@ -1,0 +1,70 @@
+import { Buffer } from 'buffer/index.js';
+import { fetch } from 'cross-fetch';
+import deepmerge from 'deepmerge';
+import { adapterForRequest, decodeRequest, processRequest, type Adapter, type Request } from '../../src';
+
+export const debugAdapter = async (adapter: Adapter, options?: { accumulateToPath?: boolean; rowLimit?: number }) => {
+    // Fetch requests from Datasette.
+    const adapterClauses = adapter.endpointUrls.map((u) =>
+        u instanceof RegExp
+            ? `endpointUrl regexp '${
+                  // JS escapes slashes in regexes, but sqlite-regex doesn't accept that.
+                  u.source.replace(/\\\//g, '/')
+              }'`
+            : `endpointUrl = '${u}'`
+    );
+    const whereClause = `endpointUrl is not null and (${adapterClauses.join(' or ')})`;
+
+    const requests: Request[] = [];
+    let nextUrl = `https://data.tweasel.org/data/requests.json?_shape=objects&_where=${encodeURIComponent(
+        whereClause
+    )}&_json=headers&_json=cookies&_nocol=initiator&_nocol=platform&_nocol=runType&_nofacet=1&_nosuggest=1&_nocount=1&_size=${
+        options?.rowLimit || 'max'
+    }`;
+    while (nextUrl && options?.rowLimit && requests.length < options?.rowLimit) {
+        const res = await fetch(nextUrl).then((r) => r.json());
+        requests.push(...res.rows);
+        nextUrl = res.next_url;
+    }
+
+    const requestsForAdapter = requests
+        // And if the content is binary, Datasette encodes it as base64
+        // (https://docs.datasette.io/en/stable/binary_data.html).
+        .map((r) => {
+            const content = r.content as string | { $base64: true; encoded: string } | undefined;
+            if (content && typeof content !== 'string' && content['$base64'] === true)
+                r.content = Buffer.from(content.encoded, 'base64').toString('binary');
+            return r;
+        })
+        // The endpoint URLs may be the same for multiple adapters, so we still need to filter the requests.
+        .filter((r) => {
+            const a = adapterForRequest(r);
+            return a && a.slug === adapter.slug && a.tracker.slug === adapter.tracker.slug;
+        });
+
+    // We want both the decoding and the full adapter result, so we unfortunately need to run the decoding twice (once
+    // manually, once through the adapter). Luckily, the decoding is fast.
+    const decodingResults = requestsForAdapter.map((r) => decodeRequest(r, adapter.decodingSteps));
+    const reduction = options?.accumulateToPath
+        ? (acc, cur) => ({
+              ...acc,
+              [`${cur.property}/${cur.context}/${cur.path}`]: acc[`${cur.property}/${cur.context}/${cur.path}`]?.concat(
+                  cur.value
+              ) || [cur.value],
+          })
+        : (acc, cur) => ({
+              ...acc,
+              [cur.property]: acc[cur.property]?.concat(cur.value) || [cur.value],
+          });
+    const adapterResults = requestsForAdapter.map((r) =>
+        processRequest(r)?.reduce<Record<string, unknown[]>>(reduction, {})
+    );
+
+    return { adapterResults, decodingResults };
+};
+
+export const mergeAdapterResults = (adapterResults: (Record<string, unknown[]> | undefined)[]) => {
+    const mergedResult = deepmerge.all(adapterResults.filter(Boolean) as Record<string, unknown[]>[]);
+    for (const key of Object.keys(mergedResult)) mergedResult[key] = [...new Set(mergedResult[key] as unknown[])];
+    return mergedResult;
+};

--- a/scripts/lib/test-data.ts
+++ b/scripts/lib/test-data.ts
@@ -63,9 +63,9 @@ export const loadTestDataFromDb = async (adapter: Adapter, options?: LoadTestDat
     const reduction = options?.accumulateToPath
         ? (acc, cur) => ({
               ...acc,
-              [`${cur.property}/${cur.context}/${cur.path}`]: acc[`${cur.property}/${cur.context}/${cur.path}`]?.concat(
-                  cur.value
-              ) || [cur.value],
+              [`${cur.property}/${cur.context}/${cur.path}`.toLowerCase()]: acc[
+                  `${cur.property}/${cur.context}/${cur.path}`.toLowerCase()
+              ]?.concat(cur.value) || [cur.value],
           })
         : (acc, cur) => ({
               ...acc,


### PR DESCRIPTION
This is a function we need in tracker-wiki, however, we already defined all the necessary code here and in tracker-wiki we copy the repository anyway, so I felt like putting the script in here instead of duplicating the code across our repositories.