### PR TITLE
Closes #73: Extract more data in google/firebaseinstallations

### DIFF
--- a/src/common/decode-functions.ts
+++ b/src/common/decode-functions.ts
@@ -20,6 +20,7 @@ const decodeFunctions: Record<DecodingStep['function'], (input: any, options?: a
         const uint8Array = gunzipSync(Buffer.from(input, 'binary'));
         return Buffer.from(uint8Array).toString('binary');
     },
+    split: (input, options) => input.toString().split(options.separator),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,8 @@ export type Identifier =
  *   result.
  * - `decodeJwt`: Decodes the payload of a JSON Web Token (JWT) string into an object.
  * - `ensureArray`: Ensures that the given value is an array. If it is not, it is wrapped in an array.
+ * - `gunzip`: Unzips a gzip-compressed blob.
+ * - `split`: Splits a string into an array using the given separator.
  * - `getProperty`: Gets a property from an object. The property name is given in the `options.path` option. This is
  *   useful for either copying a nested property to a variable, or to extract a nested property from an array when used
  *   with a `mapInput`.
@@ -134,6 +136,7 @@ export type DecodingStep = (
               | 'ensureArray'
               | 'gunzip';
       }
+    | { function: 'split'; options: { separator: string } }
     | { function: 'getProperty'; options: { path: JsonPath } }
 ) &
     (({ input: Path } | { mapInput: Path }) & { output: Identifier });


### PR DESCRIPTION
This resolves https://github.com/tweaselORG/TrackHAR/issues/73#issuecomment-2159129125. Since we are now actually parsing the encoded `x-firebase-client` values, https://github.com/tweaselORG/TrackHAR/issues/73#issuecomment-2160478068 is also handled.

This PR introduces a new `split` function that needs translations in tracker-wiki: https://github.com/tweaselORG/tracker-wiki/pull/26

Also, this relies on `onlyIf` from #83, which is not merged yet. Given the large amount of merge conflicts in that PR, I opted to not base this PR on that branch, so it will currently fail TS checking.